### PR TITLE
removed dependence on app service

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy to Azure Container App
 on:
   push:
     branches:
-    - main
+    - deploy
 
 env:
   UNIQUE_APP_NAME: orleanscart

--- a/Silo/Program.cs
+++ b/Silo/Program.cs
@@ -13,29 +13,44 @@ await Host.CreateDefaultBuilder(args)
             }
             else
             {
-                var endpointAddress =
-                    IPAddress.Parse(context.Configuration["WEBSITE_PRIVATE_IP"]);
-                var strPorts =
-                    context.Configuration["WEBSITE_PRIVATE_PORTS"].Split(',');
-                if (strPorts.Length < 2)
-                    throw new Exception("Insufficient private ports configured.");
-                var (siloPort, gatewayPort) =
-                    (int.Parse(strPorts[0]), int.Parse(strPorts[1]));
+                var siloPort = 11111;
+                var gatewayPort = 30000;
+
+                // are we running in app service?
+                if (!string.IsNullOrEmpty(context.Configuration["WEBSITE_PRIVATE_IP"]) && !string.IsNullOrEmpty(context.Configuration["WEBSITE_PRIVATE_PORTS"]))
+                {
+                    var endpointAddress =
+                        IPAddress.Parse(context.Configuration["WEBSITE_PRIVATE_IP"]);
+                    var strPorts =
+                        context.Configuration["WEBSITE_PRIVATE_PORTS"].Split(',');
+                    if (strPorts.Length < 2)
+                        throw new Exception("Insufficient private ports configured.");
+                    siloPort = int.Parse(strPorts[0]);
+                    gatewayPort = int.Parse(strPorts[1]);
+
+                    builder
+                        .ConfigureEndpoints(endpointAddress, siloPort, gatewayPort);
+                }
+                else // looks like not, presume we're in Azure Container Apps.
+                {
+                    builder
+                        .ConfigureEndpoints(siloPort, gatewayPort);
+                }
+
                 var connectionString =
                     context.Configuration["ORLEANS_AZURE_STORAGE_CONNECTION_STRING"];
 
                 builder
-                    .ConfigureEndpoints(endpointAddress, siloPort, gatewayPort)
                     .Configure<ClusterOptions>(
                         options =>
                         {
                             options.ClusterId = "ShoppingCartCluster";
                             options.ServiceId = nameof(ShoppingCartService);
-                        }).UseAzureStorageClustering(                    
-                    options => options.ConfigureTableServiceClient(connectionString));
-                builder.AddAzureTableGrainStorage(
-                    "shopping-cart",                    
-                    options => options.ConfigureTableServiceClient(connectionString));
+                        })
+                    .UseAzureStorageClustering(
+                        options => options.ConfigureTableServiceClient(connectionString))
+                    .AddAzureTableGrainStorage("shopping-cart",
+                        options => options.ConfigureTableServiceClient(connectionString));
             }
         })
     .ConfigureWebHostDefaults(


### PR DESCRIPTION
the way the code had been written prior, it was specifically looking for app service-injected environment variables that won`t be there if a customer is deploying the app to Azure Container Apps. In that case, one could use configuration settings if one desired, but for now, the two ports - silo and gateway - are presumed to be the defaults. This way it should work on either app service or container apps without modification.
